### PR TITLE
bugfix: when using proto3 optional field

### DIFF
--- a/src/main/java/org/curioswitch/common/protobuf/json/ProtoFieldInfo.java
+++ b/src/main/java/org/curioswitch/common/protobuf/json/ProtoFieldInfo.java
@@ -227,7 +227,7 @@ class ProtoFieldInfo {
     if (!isInOneof()) {
       throw new IllegalStateException("field is not in a oneof");
     }
-    return "get" + underscoresToUpperCamelCase(field.getContainingOneof().getName()) + "Case";
+    return "get" + underscoresToUpperCamelCase(field.getContainingOneof().getName());
   }
 
   /**


### PR DESCRIPTION
Hi. 
bug exists when using proto3 optional field

hello.proto
```kotlin
syntax = "proto3";
package hello;

import "google/api/annotations.proto";

option java_multiple_files = true;
option java_package = "hello.example";

service HelloService {
  rpc Hello (HelloRequest) returns (HelloResponse);
}

message HelloRequest {
  string message = 1;
  optional string optional_message = 2;
}

message HelloResponse {
  string message = 1;
}
```

service class
```kotlin
@Service
class HelloServiceGrpcService : HelloServiceGrpcKt.HelloServiceCoroutineImplBase( ){
    override suspend fun hello(request: HelloRequest): HelloResponse {
        return super.hello(request)
    }
}

```

error message
```kotlin
Caused by: java.lang.IllegalStateException: Could not find oneof case method.
```

## Cause I guess
optional field haven't ```getFieldNameCase``` method, but does have ```getField``` method

Can you review this pr ?