### PR TITLE
Add ToBuilder to incrementally add additional types to a marshaller

### DIFF
--- a/src/main/java/org/curioswitch/common/protobuf/json/MarshallerRegistry.java
+++ b/src/main/java/org/curioswitch/common/protobuf/json/MarshallerRegistry.java
@@ -62,6 +62,11 @@ final class MarshallerRegistry {
     return marshaller;
   }
 
+  /** Returns the built parsers in this registry. */
+  Map<Descriptor, TypeSpecificMarshaller<?>> getBuiltParsers() {
+    return descriptorRegistry;
+  }
+
   @SuppressWarnings("StringSplitter")
   private static String getTypeName(String typeUrl) throws InvalidProtocolBufferException {
     String[] parts = typeUrl.split("/");

--- a/src/main/java/org/curioswitch/common/protobuf/json/MessageMarshaller.java
+++ b/src/main/java/org/curioswitch/common/protobuf/json/MessageMarshaller.java
@@ -444,6 +444,8 @@ public class MessageMarshaller {
         addStandardParser(ListValueMarshaller.INSTANCE, builtParsers);
       }
 
+      // AnyMarshaller must be re-registered even if preBuiltParsers are used
+      // to be able to reference the newly registered ones.
       AnyMarshaller anyParser = new AnyMarshaller();
       addStandardParser(anyParser, builtParsers);
 

--- a/src/test/java/org/curioswitch/common/protobuf/json/MessageMarshallerIncrementalTest.java
+++ b/src/test/java/org/curioswitch/common/protobuf/json/MessageMarshallerIncrementalTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Choko (choko@curioswitch.org)
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.curioswitch.common.protobuf.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.util.JsonTestProto;
+import org.curioswitch.common.protobuf.json.test.GithubApi;
+import org.junit.jupiter.api.Test;
+
+class MessageMarshallerIncrementalTest {
+
+  @Test
+  void incrementalMarshaller() throws Exception {
+    MessageMarshaller marshaller =
+        MessageMarshaller.builder().register(GithubApi.SearchResponse.getDefaultInstance()).build();
+    GithubApi.SearchResponse response =
+        GithubApi.SearchResponse.newBuilder().setTotalCount(10).build();
+    JsonTestProto.TestAllTypes allTypes = JsonTestUtil.testAllTypesAllFields();
+    assertThat(marshaller.writeValueAsString(response)).isNotEmpty();
+    assertThatThrownBy(() -> marshaller.writeValueAsString(allTypes))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    MessageMarshaller marshaller2 =
+        marshaller.toBuilder().register(JsonTestProto.TestAllTypes.getDefaultInstance()).build();
+    assertThat(marshaller2.writeValueAsString(response)).isNotEmpty();
+    assertThat(marshaller2.writeValueAsString(allTypes)).isNotEmpty();
+  }
+}


### PR DESCRIPTION
Fixes #12 

@muhyousufmemon Can you verify this will work for your case? One point is that since this is a relatively low level utility, it avoids dealing with thread-safety, instead making all built objects immutable. I'd like to continue with this property, meaning that it will be up to the caller to deal with actual lazy registration. I guess something like this.

```
private static final ConcurrentHashMap<Message, Boolean> REGISTERED_MESSAGES = new ConcurrentHashMap<>();

private volatile MessageMarshaller marshaller;

public void handleRequest(input) {
  REGISTERED_MESSAGE.computeIfAbsent(messagePrototype, (prototype) -> {
    // Will need additional protection of volatile if simultaneous updates can be a problem, maybe just double-checked lock is better than concurrenthashmap
    marshaller = marshaller.toBuilder().register(prototype).build();
    return true;
  });

  marshaller.mergeValue(input);
```

Hopefully this looks OK